### PR TITLE
Add a missing overload for cISC4Simulator::GetSimDate

### DIFF
--- a/gzcom-dll/include/cISC4Simulator.h
+++ b/gzcom-dll/include/cISC4Simulator.h
@@ -15,6 +15,7 @@ class cISC4Simulator : public cIGZUnknown
 		virtual bool GetSimStartDate(cIGZDate& sDate) = 0;
 		
 		virtual cIGZDate* GetSimDate(void) = 0;
+		virtual void GetSimDate(long& year, long& month, long& day, long& dayOfYear, long& weekDay) = 0;
 		virtual int32_t GetSimDateNumber(void) = 0;
 
 		virtual bool Pause(void) = 0;


### PR DESCRIPTION
Without this overload the compiler fails to resolve calls to the existing GetSimDate(void) overload.