### PR TITLE
Fix the cIGZSystemService definitions

### DIFF
--- a/gzcom-dll/include/cIGZFrameWork.h
+++ b/gzcom-dll/include/cIGZFrameWork.h
@@ -121,7 +121,7 @@ class cIGZFrameWork : public cIGZUnknown
 		/**
 		 * @brief Called whenever the game has an idle tick
 		 */
-		virtual bool OnIdle(void) = 0;
+		virtual bool OnIdle(uint32_t unknown1) = 0;
 
 		/**
 		 * @return Whether or not tick events are enabled

--- a/gzcom-dll/include/cIGZMessageServer.h
+++ b/gzcom-dll/include/cIGZMessageServer.h
@@ -57,7 +57,7 @@ class cIGZMessageServer : public cIGZUnknown
 		/**
 		 * @brief A service event for processing posted messages on each tick
 		 */
-		virtual bool OnTick(void) = 0;
+		virtual bool OnTick(uint32_t unknown1) = 0;
 
 		virtual uint32_t GetMessageQueueSize(void) = 0;
 		virtual cIGZMessageServer* SetAlwaysClearQueueOnTick(bool bToggle) = 0;

--- a/gzcom-dll/include/cIGZMessageServer2.h
+++ b/gzcom-dll/include/cIGZMessageServer2.h
@@ -21,7 +21,7 @@ class cIGZMessageServer2 : public cIGZUnknown
 		virtual bool GeneralMessagePostToTarget(cIGZMessage2* pMessage, cIGZMessageTarget2* pTarget) = 0;
 		virtual bool CancelGeneralMessagePostsToTarget(cIGZMessageTarget2* pTarget) = 0;
 		
-		virtual bool OnTick(void) = 0;
+		virtual bool OnTick(uint32_t unknown1) = 0;
 
 		virtual uint32_t GetMessageQueueSize(void) = 0;
 		virtual cIGZMessageServer2* SetAlwaysClearQueueOnTick(bool bToggle) = 0;

--- a/gzcom-dll/include/cIGZSystemService.h
+++ b/gzcom-dll/include/cIGZSystemService.h
@@ -57,7 +57,7 @@ class cIGZSystemService : public cIGZUnknown
 		 * The service must be registered to receive active tick callbacks via
 		 * cIGZFrameWork::AddToTick(cIGZSystemService* pService)
 		 */
-		virtual bool OnTick(void) = 0;
+		virtual bool OnTick(uint32_t unknown1) = 0;
 
 		/**
 		 * @brief A callback for each idle tick when the game is not focused
@@ -65,5 +65,10 @@ class cIGZSystemService : public cIGZUnknown
 		 * The service must be registered to receive idle tick callbacks via
 		 * cIGZFrameWork::AddToOnIdle(cIGZSystemService* pService)
 		 */
-		virtual bool OnIdle(void) = 0;
+		virtual bool OnIdle(uint32_t unknown1) = 0;
+
+		/**
+		 * @return This service's tick priority. Lower values yield more priority
+		 */
+		virtual int32_t GetServiceTickPriority() = 0;
 };

--- a/gzcom-dll/include/cISC4App.h
+++ b/gzcom-dll/include/cISC4App.h
@@ -18,7 +18,7 @@ class cISC4RenderProperties;
 class cISC4App : public cIGZUnknown
 {
 	public:
-		virtual bool OnIdle(void) = 0;
+		virtual bool OnIdle(uint32_t unknown1) = 0;
 
 		virtual bool RunMessageServerPump(uint32_t dwMinMessages, uint32_t dwMaxMessages, uint32_t dwMaxTime) = 0;
 		virtual bool RunMessageServer2Pump(uint32_t dwMinMessages, uint32_t dwMaxMessages, uint32_t dwMaxTime) = 0;


### PR DESCRIPTION
`OnTick` and `OnIdle` take a single integer parameter, which appears to be
some kind of incrementing counter.
The `cIGZSystemService`  header was also missing the `GetServiceTickPriority` method, which
was causing it to crash when calling `AddToTick`.

Fixed the `OnTick` and `OnIdle` method signatures in various headers.