### PR TITLE
fix/docs: Add and document missing PickOccupant method

### DIFF
--- a/gzcom-dll/include/cISC4View3DWin.h
+++ b/gzcom-dll/include/cISC4View3DWin.h
@@ -6,6 +6,7 @@ class cIGZString;
 class cIGZWin;
 class cIGZWinKeyAccelerator;
 class cISC43DRender;
+class cISC4Occupant;
 class cISC4ViewInputControl;
 class cISC4ViewManager;
 class cS3DVector3;
@@ -60,11 +61,29 @@ class cISC4View3DWin : public cIGZUnknown
 		virtual bool ScrollStop(void) = 0;
 		virtual bool KillKeyboardScrolling(void) = 0;
 
-		virtual bool PickTerrain(int32_t, int32_t, float*, bool) = 0;
+		/// <summary>
+		/// Converts screen coordinates to 3D world coordinates by intersecting with terrain.
+		/// </summary>
+		/// <param name="screenX">Screen X coordinate</param>
+		/// <param name="screenZ">Screen Z coordinate</param>
+		/// <param name="pWorldCoordsOut">Output array of 3 floats for world coordinates [x,y,z]</param>
+		/// <param name="bUnknownFlag">Purpose unclear - likely controls picking precision/quality.
+		/// Passed as second bool to underlying cSC43DRender::PickTerrain method.</param>
+		/// <returns>true if terrain was successfully picked, false otherwise</returns>
+		virtual bool PickTerrain(int32_t screenX, int32_t screenZ, float* pWorldCoordsOut, bool bUnknownFlag) = 0;
+		
+		/// <summary>
+		/// Converts screen coordinates to a cISC4Occupant at that location.
+		/// </summary>
+		/// <param name="screenX">Screen X coordinate</param>
+		/// <param name="screenZ">Screen Z coordinate</param>
+		/// <param name="pOccupantOut">Output reference to occupant pointer (set to found occupant or null)</param>
+		/// <returns>true if an occupant was found, false otherwise</returns>
+		virtual bool PickOccupant(int32_t screenX, int32_t screenZ, cISC4Occupant*& pOccupantOut) = 0;
+		
 		virtual void DisplayTerrainPickDebugString(int32_t, int32_t) = 0; // no-op
-
 		virtual bool GetTerrainQueryEnabled(void) = 0;
-		virtual bool SetCursorText(uint32_t, uint32_t, cIGZString const&, cIGZString const&, int32_t) = 0;
+		virtual bool SetCursorText(uint32_t, uint32_t, cIGZString const*, cIGZString const*, int32_t) = 0;
 		virtual bool ClearCursorText(uint32_t) = 0;
 		virtual bool SetCostIndicator(uint32_t) = 0;
 		virtual bool SetCostIndicator(uint32_t, uint32_t) = 0;


### PR DESCRIPTION
 The cISC4View3DWin header had a missing method, `PickOccupant` that should be between `PickTerrain` and `DisplayTerrainPickDebugString`. It was probably skipped over by accident when creating the original header.

This PR amends that and adds some additional documentation to two involved methods.