### PR TITLE
fix: Update misleading param names in cISC4LotManager

### DIFF
--- a/gzcom-dll/include/cISC4LotManager.h
+++ b/gzcom-dll/include/cISC4LotManager.h
@@ -37,11 +37,11 @@ class cISC4LotManager : public cIGZUnknown
 		virtual int32_t GetLotSavvyTerrainAltitude(float fPointX, float fPointY, bool& bSucceeded) = 0;
 		virtual int32_t GetLotSavvyCellAltitude(int32_t nCellX, int32_t nCellZ, bool& bSucceeded) = 0;
 
-		virtual bool CanCreateLot(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nBottomRightCellX, int32_t nBottomRightCellZ, bool bZoneNotNeeded, bool bIgnoreConfig, cISC4LotConfiguration* pConfig) = 0;
+		virtual bool CanCreateLot(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nLotWidth, int32_t nLotHeight, bool bZoneNotNeeded, bool bIgnoreConfig, cISC4LotConfiguration* pConfig) = 0;
 		virtual bool CanCreatePloppedLot(SC4Rect<long> sBounds, int32_t nUnknown, cISC4LotConfiguration* pConfig) = 0;
 
-		virtual bool CreateLotIfPossible(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nBottomRightCellX, int32_t nBottomRightCellZ, int32_t nUnknown, bool bZoneNotNeeded, bool bIgnoreConfig, cISC4LotConfiguration* pConfig) = 0;
-		virtual bool CreateLot(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nBottomRightCellX, int32_t nBottomRightCellZ, int32_t nFacing, cISC4Lot*& pLot) = 0;
+		virtual bool CreateLotIfPossible(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nLotWidth, int32_t nLotHeight, int32_t nUnknown, bool bZoneNotNeeded, bool bIgnoreConfig, cISC4LotConfiguration* pConfig) = 0;
+		virtual bool CreateLot(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nLotWidth, int32_t nLotHeight, int32_t nFacing, cISC4Lot*& pLot) = 0;
 		virtual bool DeleteLot(cISC4Lot* pLot) = 0;
 		virtual bool DeleteLots(int32_t nTopLeftCellX, int32_t nTopLeftCellZ, int32_t nBottomRightCellX, int32_t nBottomRightCellZ) = 0;
 


### PR DESCRIPTION
::CanCreateLot, ::CreateLotIfPossible and ::CreateLot have nLotWidth and nLotHeight as 3rd and 4th parameter.

For `CreateLot` use of the method in game has experimentally shown that the 3rd and 4th parameters are _not_ nBottomRightCellX and nBottomRightCellZ. Decompilation agrees.

For `CreateLotIfPossible` and `CanCreateLot`, I didn't test in game, but the decompilation shows similar structure.

I also checked `DeleteLots`: that one does use the corner coordinates, so no changed needed. Given the purpose of that method and its name, that makes sense too.