### PR TITLE
feat: add a minimal CMake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 
 # Mac files and directories
 .DS_Store
+
+# CLion / JetBrains IDEs
+.idea/
+*.iml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(gzcom_dll LANGUAGES CXX)
+
+file(GLOB GZCOM_DLL_SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/gzcom-dll/src/*.cpp"
+)
+
+add_library(gzcom_dll STATIC
+    ${GZCOM_DLL_SOURCES}
+)
+
+target_include_directories(gzcom_dll PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/gzcom-dll/include"
+)
+
+if (MSVC)
+    target_compile_definitions(gzcom_dll PUBLIC _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(gzcom_dll PRIVATE
+        /W3
+        /sdl
+        "$<$<CONFIG:Debug>:/MTd>"
+        "$<$<CONFIG:Release>:/MT>"
+    )
+endif()
+
+target_compile_features(gzcom_dll PUBLIC cxx_std_20)


### PR DESCRIPTION
- Allows for easier integration of gzcom_dll headers & source in CMake-managed projects (i.e. in CLion etc.)
- CMakeLists.txt configuration mirrors as closely as possible the existing .vcxproj file (C++20, level 3 warnings, check SDL and _CRT_SECURE_NO_WARNINGS) 