### PR TITLE
fix: wrong method order in cISTESurfaceWater for IsNavigable overloads

### DIFF
--- a/gzcom-dll/include/cISTESurfaceWater.h
+++ b/gzcom-dll/include/cISTESurfaceWater.h
@@ -4,6 +4,7 @@
  * cISTESurfaceWater.h
  *
  * Copyright (C) 2025 Nicholas Hayes
+ * Copyright (C) 2026 Casper Van Gheluwe
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,8 +36,24 @@ public:
 	virtual float GetWaterDepthAtVertex(int32_t index) const = 0;
 	virtual float GetWaterDepthForCell(int32_t x, int32_t z) const = 0;
 
-	virtual bool IsNavigable(int32_t param_1, int32_t param_2, int32_t param_3, cISC4Lot* param_4) const = 0;
-	virtual bool IsNavigable(cS3DVector3 param_1, int32_t param_2, cISC4Lot* param_3) const = 0;
+	/**
+	 * @param position World-space 3D position, uses the X and Z position, ignoring Y
+	 * @param radius Search radius around the position, in cells
+	 * @param lot Lot to exclude from conflict checks (nullptr = no lot excluded)
+	 * @return true if the area is navigable. In other words, there are no obstructions
+	 *		   within the radius around the position
+	 */
+	virtual bool IsNavigable(cS3DVector3* position, int32_t radius, cISC4Lot* lot) const = 0;
+
+	/**
+	 * @param cellX Terrain cell X coordinate
+	 * @param cellZ Terrain cell Z coordinate
+	 * @param radius Search radius in cells
+	 * @param lot Lot to exclude from conflict checks (nullptr = no lot excluded)
+	 * @return true if the area is navigable. In other words, there are no obstructions
+	 *		   within the radius around the position
+	 */
+	virtual bool IsNavigable(int32_t cellX, int32_t cellZ, int32_t radius, cISC4Lot* lot) const = 0;
 
 	virtual cISC4SimGrid<uint16_t>* GetBodyOfWaterMap() const = 0;
 	virtual float AltitudeAtWhichFloodingWillOccur(int32_t x, int32_t z) = 0;


### PR DESCRIPTION
Method order was switched again in v641 Windows compared to the Mac binary.