### PR TITLE
fix: correct cast in cSC4BaseViewInputControl::QueryInterface

### DIFF
--- a/gzcom-dll/src/cSC4BaseViewInputControl.cpp
+++ b/gzcom-dll/src/cSC4BaseViewInputControl.cpp
@@ -36,7 +36,7 @@ bool cSC4BaseViewInputControl::QueryInterface(uint32_t riid, void** ppvObj)
 {
 	if (riid == GZIID_cISC4ViewInputControl)
 	{
-		*ppvObj = this;
+		*ppvObj = static_cast<cISC4ViewInputControl*>(this);
 		AddRef();
 
 		return true;


### PR DESCRIPTION
cSC4BaseViewInputControl has multiple inheritance from cIGZUnknown and cISC4ViewInputControl, so its QI method should cast its this pointer correctly.